### PR TITLE
BM-36: Prepare commit message hook

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -4,4 +4,4 @@ repos:
     hooks:
     -   id: conventional-pre-commit
         stages: [commit-msg]
-        args: [ops] # optional: list of Conventional Commits types to allow e.g. [feat, fix, ci, chore, test]
+        args: [ops, docs] # optional: list of Conventional Commits types to allow e.g. [feat, fix, ci, chore, test]

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -4,4 +4,4 @@ repos:
     hooks:
     -   id: conventional-pre-commit
         stages: [commit-msg]
-        args: [ops, docs] # optional: list of Conventional Commits types to allow e.g. [feat, fix, ci, chore, test]
+        args: [ops] # optional: list of Conventional Commits types to allow e.g. [feat, fix, ci, chore, test]

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,0 +1,7 @@
+repos:
+-   repo: https://github.com/compilerla/conventional-pre-commit
+    rev: v2.1.1
+    hooks:
+    -   id: conventional-pre-commit
+        stages: [commit-msg]
+        args: [ops] # optional: list of Conventional Commits types to allow e.g. [feat, fix, ci, chore, test]

--- a/README.md
+++ b/README.md
@@ -2,6 +2,8 @@
 
 A building management system developed using Django Rest Framework and Angular.
 
+[![pre-commit](https://img.shields.io/badge/pre--commit-enabled-brightgreen?logo=pre-commit)](https://github.com/pre-commit/pre-commit)
+
 <div align="center">
   <img src="https://github.com/syfqpie/building-management/blob/master/screenshots/login.png"
     width="700" />


### PR DESCRIPTION
Added git prepare commit message hooks. Follows conventional commits - https://www.conventionalcommits.org/en/v1.0.0/ 
- configured to use https://github.com/compilerla/conventional-pre-commit to force conventional commits